### PR TITLE
Update CI for Linux and save the binary.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: main CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     # install deps
     - uses: actions/checkout@v4
     - name: install debian-packaged dependencies
-      run: sudo apt install -y libwxgtk3.0-gtk3-dev libboost-graph1.74.0 libboost-serialization1.74.0 libboost-all-dev
+      run: sudo apt install -y libwxgtk3.2-dev libboost-graph1.83.0 libboost-serialization1.83.0 libboost-all-dev
 
     # build
     - name: build netlist-viewer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,13 @@ jobs:
     - name: build netlist-viewer
       run: cd NetlistViewer/build/linux && make
 
+    # save binary
+    - name: Save
+      uses: actions/upload-artifact@v4
+      with:
+        name: NetlistViewer, Linux X86-64
+        path: NetlistViewer/build/linux/NetlistViewer
+
   WindowsBuild:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
Being lazy, I decided to let github build for me, which needed some CI changes.  It did not work out for me, as the required libraries seem unavailable on my Debian.  But these changes may be useful.

The Windows build was also broken, but I have no idea how to fix.  Using an older runner does not help.
